### PR TITLE
Support for per-commit patch files

### DIFF
--- a/build-for-compare.py
+++ b/build-for-compare.py
@@ -232,7 +232,7 @@ def main():
             try:
                 os.makedirs(commitdir)
             except FileExistsError:
-                logger.error("%s already exists, remove it to continue" % commitdir)
+                logger.error("%s already exists, remove it to continue" % commitdir) 
                 exit(1)
             check_call([GIT,'reset','--hard'])
             check_call([GIT,'clean','-f','-x','-d'])
@@ -249,7 +249,7 @@ def main():
             logger.info('Running configure script')
             opt = shell_join(args.opt)
             check_call(['./configure', '--disable-hardening', '--with-incompatible-bdb', '--without-cli', '--disable-tests', '--disable-ccache',
-                'CPPFLAGS='+(' '.join(cppflags)),
+                'CPPFLAGS='+(' '.join(cppflags)), 
                 'CFLAGS='+opt, 'CXXFLAGS='+opt, 'LDFLAGS='+opt] + CONFIGURE_EXTRA)
 
             for name in args.executables:
@@ -265,7 +265,7 @@ def main():
             logger.info('Performing basic analysis pass...')
             objdump_all(commitdir_obj, commitdir)
 
-        if len(args.commitids)>1:
+        if len(args.commitids)>1: 
             logger.info('Use these commands to compare results:')
             logger.info('$ sha256sum %s/*.stripped' % (args.tgtdir))
             logger.info('$ git diff -W --word-diff %s %s' % (os.path.join(args.tgtdir,args.commitids[0]), os.path.join(args.tgtdir,args.commitids[1])))
@@ -274,3 +274,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/patches/stripbuildinfo-with-using-ns.patch
+++ b/patches/stripbuildinfo-with-using-ns.patch
@@ -15,7 +15,9 @@ diff --git a/src/main.cpp b/src/main.cpp
 index cb6e942..c3fa883 100644
 --- a/src/main.cpp
 +++ b/src/main.cpp
-@@ -50,8 +50,4 @@
+@@ -50,10 +50,6 @@
+
+ using namespace std;
 
 -#if defined(NDEBUG)
 -# error "Bitcoin cannot be compiled without assertions."

--- a/patches/stripbuildinfo-without-using-ns.patch
+++ b/patches/stripbuildinfo-without-using-ns.patch
@@ -15,9 +15,7 @@ diff --git a/src/main.cpp b/src/main.cpp
 index cb6e942..c3fa883 100644
 --- a/src/main.cpp
 +++ b/src/main.cpp
-@@ -50,10 +50,6 @@
-
- using namespace std;
+@@ -50,8 +50,4 @@
 
 -#if defined(NDEBUG)
 -# error "Bitcoin cannot be compiled without assertions."

--- a/patches/stripbuildinfo-without-using-ns.patch
+++ b/patches/stripbuildinfo-without-using-ns.patch
@@ -11,12 +11,27 @@ index bfe9e16..b4d704b 100644
 
  static std::string FormatVersion(int nVersion)
  {
-diff --git a/src/main.cpp b/src/main.cpp
-index cb6e942..c3fa883 100644
---- a/src/main.cpp
-+++ b/src/main.cpp
-@@ -50,8 +50,4 @@
-
+diff --git a/src/net_processing.cpp b/src/net_processing.cpp
+index 7471672..ab6a0d5 100644
+--- a/src/net_processing.cpp
++++ b/src/net_processing.cpp
+@@ -34,8 +34,4 @@
+ 
+-#if defined(NDEBUG)
+-# error "Bitcoin cannot be compiled without assertions."
+-#endif
+-
+ int64_t nTimeBestReceived = 0; // Used only to inform the wallet of when we last received a block
+ 
+ struct IteratorComparator
+diff --git a/src/validation.cpp b/src/validation.cpp
+index a31fba4..f473cec 100644
+--- a/src/validation.cpp
++++ b/src/validation.cpp
+@@ -45,10 +45,6 @@
+ #include <boost/math/distributions/poisson.hpp>
+ #include <boost/thread.hpp>
+ 
 -#if defined(NDEBUG)
 -# error "Bitcoin cannot be compiled without assertions."
 -#endif

--- a/patches/stripbuildinfo.patch
+++ b/patches/stripbuildinfo.patch
@@ -5,18 +5,20 @@ index bfe9e16..b4d704b 100644
 @@ -67,7 +67,7 @@ const std::string CLIENT_NAME("Satoshi");
  #endif
  #endif
-
+ 
 -const std::string CLIENT_BUILD(BUILD_DESC CLIENT_VERSION_SUFFIX);
 +const std::string CLIENT_BUILD("");
-
+ 
  static std::string FormatVersion(int nVersion)
  {
 diff --git a/src/main.cpp b/src/main.cpp
 index cb6e942..c3fa883 100644
 --- a/src/main.cpp
 +++ b/src/main.cpp
-@@ -50,8 +50,4 @@
-
+@@ -50,10 +50,6 @@
+ 
+ using namespace std;
+ 
 -#if defined(NDEBUG)
 -# error "Bitcoin cannot be compiled without assertions."
 -#endif
@@ -34,20 +36,20 @@ index 7733910..48520d7 100644
  #endif
 -#define AssertLockHeld(cs) AssertLockHeldInternal(#cs, __FILE__, __LINE__, &cs)
 +#define AssertLockHeld(cs) AssertLockHeldInternal(#cs, __FILE__, 0, &cs)
-
+ 
  /**
   * Wrapped boost mutex: supports recursive locking, but no waiting
 @@ -174,13 +174,13 @@ typedef CMutexLock<CCriticalSection> CCriticalBlock;
  #define PASTE(x, y) x ## y
  #define PASTE2(x, y) PASTE(x, y)
-
+ 
 -#define LOCK(cs) CCriticalBlock PASTE2(criticalblock, __COUNTER__)(cs, #cs, __FILE__, __LINE__)
 -#define LOCK2(cs1, cs2) CCriticalBlock criticalblock1(cs1, #cs1, __FILE__, __LINE__), criticalblock2(cs2, #cs2, __FILE__, __LINE__)
 -#define TRY_LOCK(cs, name) CCriticalBlock name(cs, #cs, __FILE__, __LINE__, true)
 +#define LOCK(cs) CCriticalBlock PASTE2(criticalblock, __COUNTER__)(cs, #cs, __FILE__, 0)
 +#define LOCK2(cs1, cs2) CCriticalBlock criticalblock1(cs1, #cs1, __FILE__, 0), criticalblock2(cs2, #cs2, __FILE__, 0)
 +#define TRY_LOCK(cs, name) CCriticalBlock name(cs, #cs, __FILE__, 0, true)
-
+ 
  #define ENTER_CRITICAL_SECTION(cs)                            \
      {                                                         \
 -        EnterCritical(#cs, __FILE__, __LINE__, (void*)(&cs)); \

--- a/patches/stripbuildinfo.patch
+++ b/patches/stripbuildinfo.patch
@@ -11,12 +11,27 @@ index bfe9e16..b4d704b 100644
  
  static std::string FormatVersion(int nVersion)
  {
-diff --git a/src/main.cpp b/src/main.cpp
-index cb6e942..c3fa883 100644
---- a/src/main.cpp
-+++ b/src/main.cpp
-@@ -50,10 +50,6 @@
+diff --git a/src/net_processing.cpp b/src/net_processing.cpp
+index 7471672..ab6a0d5 100644
+--- a/src/net_processing.cpp
++++ b/src/net_processing.cpp
+@@ -34,10 +34,6 @@
  
+ using namespace std;
+ 
+-#if defined(NDEBUG)
+-# error "Bitcoin cannot be compiled without assertions."
+-#endif
+-
+ int64_t nTimeBestReceived = 0; // Used only to inform the wallet of when we last received a block
+ 
+ struct IteratorComparator
+diff --git a/src/validation.cpp b/src/validation.cpp
+index a31fba4..f473cec 100644
+--- a/src/validation.cpp
++++ b/src/validation.cpp
+@@ -45,10 +45,6 @@
+
  using namespace std;
  
 -#if defined(NDEBUG)


### PR DESCRIPTION
In the process of getting rid of `using namespace` stuff in Bitcoin Core, I ran into problems with this tool, as the patch could not be applied to the new commit. Fixing it, it would no longer work for the old commit, so a way to specify two separate patches was necessary.

This PR adds support for per-commit-hash patch filename for cases where the stripbuildinfo.patch git apply cannot be done to both commits due to changes in patch-sensitive areas in one of them. The `patches='patch1, patch2, ...'` argument is added, defaulting to `'stripbuildinfo.patch'`. Patches are expected to reside in the `patches/` folder inside `bitcoin-maintainer-tools/`.
