### PR TITLE
Instead of exiting, skip commits that exist in tgtdir.

### DIFF
--- a/build-for-compare.py
+++ b/build-for-compare.py
@@ -249,8 +249,8 @@ def main():
             try:
                 os.makedirs(commitdir)
             except FileExistsError:
-                logger.error("%s already exists, remove it to continue" % commitdir) 
-                exit(1)
+                logger.error("%s already exists; skipping" % commitdir) 
+                continue
             check_call([GIT,'reset','--hard'])
             check_call([GIT,'clean','-f','-x','-d'])
             check_call([GIT,'checkout',commit])


### PR DESCRIPTION
When comparing against the same base commit (upstream/master), it is convenient to leave tgtdir intact and to "build upon it". The problem is that the script will `exit(1)` if it runs into an existing commit dir, which 
1. means you have to explicitly remove the base commit when you are appending builds, and
2. means you do not get helpful messages about how to compare the two commits once you do so, since you then only have one commit listed.

This PR will simply skip the build process for existing commit dirs and present the helpful notices as normal. You may be forced to manually `rm -rf` the dir for a broken commitdir at times but it's worth it I think.
